### PR TITLE
Resolve #58

### DIFF
--- a/includes/events/comment/class-comment-hook.php
+++ b/includes/events/comment/class-comment-hook.php
@@ -26,7 +26,7 @@ class Comment_Hook extends Hook {
 	 */
 	public function comment_new( $comment_id, $approved ) {
 
-		if ( 'spam' === $approved ) {
+		if ( 'spam' === $approved || 'trash' === $approved ) {
 			return;
 		}
 


### PR DESCRIPTION
Comments containing strings on the block list are `$comment_approved === 'trash'`:
https://developer.wordpress.org/reference/hooks/comment_post/#comment-4879